### PR TITLE
Fix client-side exception thrown in admin

### DIFF
--- a/kidneys_misc.js
+++ b/kidneys_misc.js
@@ -128,11 +128,13 @@
           } catch (e) {}
         });
       });
-      // utility for watertree modal selection.
-      $('.modal-watertree').magnificPopup({
-        type:'inline',
-        midClick: true
-      });
+      if ($('.modal-watertree').length) {
+        // utility for watertree modal selection.
+        $('.modal-watertree').magnificPopup({
+          type: 'inline',
+          midClick: true
+        });
+      }
     }
   }
 


### PR DESCRIPTION
This was preventing fieldsets from opening, and other client-side controls that relied on javascript on the admin screen.